### PR TITLE
remove versions and approvals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ htmlcov/
 virtualenv
 *.sw*
 .cache/
+*.iml

--- a/kio/cli.py
+++ b/kio/cli.py
@@ -5,7 +5,7 @@ import json
 
 import time
 import zign.api
-from clickclick import AliasedGroup, print_table, OutputFormat, Action, warning
+from clickclick import AliasedGroup, print_table, OutputFormat, Action
 
 import kio
 import stups_cli.config

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ class PyTest(TestCommand):
     def run_tests(self):
         try:
             import pytest
-        except:
+        except BaseException:
             raise RuntimeError('py.test is not installed, run: pip install pytest')
         params = {'args': self.test_args}
         if self.cov:

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def read_version(package):
 NAME = 'stups-kio'
 MAIN_PACKAGE = 'kio'
 VERSION = read_version(MAIN_PACKAGE)
-DESCRIPTION = 'Simple command line utility to manage Kio applications and application versions'
+DESCRIPTION = 'Simple command line utility to manage Kio applications'
 LICENSE = 'Apache License 2.0'
 URL = 'https://github.com/zalando-stups/kio-cli'
 AUTHOR = 'Henning Jacobs'


### PR DESCRIPTION
Application versions and approvals are obsolete. So they should be
removed from the CLI.