### PR TITLE
Fix for python 3.11

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -6,7 +6,9 @@ notifications:
 pipeline:
   - id: build
     type: script
-    overlay: ci/python
+    vm_config:
+      type: linux
+      image: cdp-runtime/python-3.9
     commands:
     - desc: "Install dependencies"
       cmd: pip install -r requirements.txt

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -11,11 +11,14 @@ pipeline:
       image: cdp-runtime/python-3.9
     commands:
     - desc: "Install dependencies"
-      cmd: pip install -r requirements.txt
+      cmd: |
+        pip install -r requirements.txt
     - desc: "Run Tests"
       cmd: python3 setup.py test
     - desc: "Check code style"
-      cmd: python3 setup.py flake8
+      cmd: |
+        pip3 install flake8
+        flake8
     - desc: "Build docker image that will upload package"
       cmd: |
         VERSION=$(./next-version)

--- a/kio/time.py
+++ b/kio/time.py
@@ -10,8 +10,7 @@ TIME_UNITS = {
 }
 
 TIME_PATTERN = \
-    re.compile(r"""
-    (?x)
+    re.compile(r"""(?x)
     ^
     (?:
         (?P<magnitude> [+-]? \d+ )


### PR DESCRIPTION
This makes the regex work with Python 3.11. Without it you get the error:

```
re.error: global flags not at the start of the expression at position 5 (line 2, column 5)
```